### PR TITLE
Catch long datetimes

### DIFF
--- a/hstsparser.py
+++ b/hstsparser.py
@@ -137,7 +137,10 @@ if args.firefox:
             record[0] = re.search(r"^([^:\^]+)", record[0]).group(0)
             record[2] = serial_date_to_string(record[2])
             cleaned = record[3].split(",")
-            record[3] = datetime.datetime.fromtimestamp(int(cleaned[0]) / 1000)
+            try:
+                record[3] = datetime.datetime.fromtimestamp(int(cleaned[0]) / 1000)
+            except (OSError, ValueError):
+                record[3] = datetime.datetime.fromtimestamp(32503680000) # 3000-01-01 00:00:00
             if int(cleaned[2]):
                 record.append("Yes")
             else:


### PR DESCRIPTION
If a date is too far into the future to be processed it will be replaced with `3000-01-01 00:00:00`.

This is a limitation of the `datetime` library.